### PR TITLE
downgrade required webvtt version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ num2words==0.5.6
 pytest==3.8.1
 termcolor==1.1.0
 tqdm==4.26.0
-webvtt-py==0.4.2
+webvtt-py>=0.3.0


### PR DESCRIPTION
Not all environments support WebVTT-py>=0.4, so I'm downgrading this to 0.3.0