### PR TITLE
generalize audio corpus prep

### DIFF
--- a/asrtoolkit/data_structures/audio_file.py
+++ b/asrtoolkit/data_structures/audio_file.py
@@ -72,7 +72,7 @@ class audio_file(object):
       file_name = ".".join(file_name.split(".")[-1]) + ".sph"
 
     file_name = sanitize_hyphens(file_name)
-    subprocess.call(["sox {} {} rate 16k remix 1".format(self.location, file_name)], shell=True)
+    subprocess.call(["sox {} {} rate 16k remix 1,2".format(self.location, file_name)], shell=True)
 
     # return new object
     return audio_file(file_name)

--- a/asrtoolkit/data_structures/audio_file.py
+++ b/asrtoolkit/data_structures/audio_file.py
@@ -5,7 +5,7 @@ Module for holding information about an audio file and doing basic conversions
 
 import os
 import subprocess
-from asrtoolkit.file_utils.name_cleaners import sanitize_hyphens, generate_segmented_file_name
+from asrtoolkit.file_utils.name_cleaners import sanitize_hyphens, generate_segmented_file_name, strip_extension
 
 
 def cut_utterance(source_audio_file, target_audio_file, start_time, end_time, sample_rate=16000):
@@ -69,7 +69,7 @@ class audio_file(object):
     """
     if file_name.split(".")[-1] != 'sph':
       print("Forcing training data to use SPH file format")
-      file_name = ".".join(file_name.split(".")[-1]) + ".sph"
+      file_name = strip_extension(file_name) + ".sph"
 
     file_name = sanitize_hyphens(file_name)
     subprocess.call(["sox {} {} rate 16k remix -".format(self.location, file_name)], shell=True)

--- a/asrtoolkit/data_structures/audio_file.py
+++ b/asrtoolkit/data_structures/audio_file.py
@@ -72,7 +72,7 @@ class audio_file(object):
       file_name = ".".join(file_name.split(".")[-1]) + ".sph"
 
     file_name = sanitize_hyphens(file_name)
-    subprocess.call(["sox {} {} rate 16k remix 1,2".format(self.location, file_name)], shell=True)
+    subprocess.call(["sox {} {} rate 16k remix -".format(self.location, file_name)], shell=True)
 
     # return new object
     return audio_file(file_name)

--- a/asrtoolkit/data_structures/corpus.py
+++ b/asrtoolkit/data_structures/corpus.py
@@ -72,13 +72,16 @@ class corpus(object):
         for fl in get_files(self.location, audio_extension):
           filename = strip_extension(fl)
           if filename not in candidate_examples and os.path.exists(filename + ".stm"):
-            candidate_examples[fl] = {'audio_file': audio_file(fl), 'transcript_file': time_aligned_text(fl + ".stm")}
+            candidate_examples[fl] = {
+              'audio_file': audio_file(fl),
+              'transcript_file': time_aligned_text(filename + ".stm")
+            }
 
       self.exemplars = [
         exemplar({
           "audio_file": eg['audio_file'],
           "transcript_file": eg['transcript_file']
-        }) for eg in candidate_examples
+        }) for fn, eg in list(candidate_examples.items())
       ]
 
   def validate(self):

--- a/asrtoolkit/data_structures/corpus.py
+++ b/asrtoolkit/data_structures/corpus.py
@@ -59,11 +59,11 @@ class corpus(object):
 
   def __init__(self, input_dict=None):
     """
-      Initialize from location and populate list of SPH and STM files into segments
+      Initialize from location and populate list of SPH, WAV, or MP3 audio files and STM files into segments
     """
     self.__dict__.update(input_dict if input_dict else {})
     if not self.exemplars:
-      audio_files = [audio_file(_) for _ in sorted(get_files(self.location, "sph"))]
+      audio_files = sorted([audio_file(_) for _ in get_files(self.location, "sph")] + [audio_file(_) for _ in get_files(self.location, "wav")] + [audio_file(_) for _ in get_files(self.location, "mp3")])
       transcript_files = [time_aligned_text(_) for _ in sorted(get_files(self.location, "stm"))]
       self.exemplars = [
         exemplar({

--- a/asrtoolkit/file_utils/name_cleaners.py
+++ b/asrtoolkit/file_utils/name_cleaners.py
@@ -11,6 +11,13 @@ def basename(file_name):
   return file_name.split("/")[-1]
 
 
+def strip_extension(file_name):
+  """
+    Reutrns file without extension
+  """
+  return ".".join(file_name.split(".")[:-1])
+
+
 def sanitize_hyphens(file_name):
   """
     Replace hyphens with underscores if present in file name
@@ -20,7 +27,7 @@ def sanitize_hyphens(file_name):
       "Replacing hyphens with underscores in SPH file output - "
       "check to make sure your audio files and transcript files match"
     )
-    file_name = "/".join(file_name.split("/")[:-1] + [file_name.split("/")[-1].replace("-", "_")])
+    file_name = "/".join(file_name.split("/")[:-1] + [basename(file_name).replace("-", "_")])
   return file_name
 
 
@@ -28,5 +35,5 @@ def generate_segmented_file_name(target_dir, file_name, iseg):
   """
     Take a target location, a current location, and a segment number and generate a target filename
   """
-  return target_dir + "/" + ".".join(file_name.split("/")[-1].split(".")[:-1]) + \
+  return target_dir + "/" + basename(strip_extension(file_name)) + \
             "_seg_{:05d}.".format(iseg) + file_name.split(".")[-1]

--- a/asrtoolkit/file_utils/name_cleaners.py
+++ b/asrtoolkit/file_utils/name_cleaners.py
@@ -15,7 +15,7 @@ def strip_extension(file_name):
   """
     Reutrns file without extension
   """
-  return ".".join(file_name.split(".")[:-1])
+  return ".".join(file_name.split(".")[:-1]) if file_name else ""
 
 
 def sanitize_hyphens(file_name):


### PR DESCRIPTION
This PR enables audio corpus objects to accept SPH, WAV, and MP3 files from directories. It still expects file names to match between audio files and transcript STM files.

Further, this PR mixes stereo channels down to mono instead of discarding extra channels.

Fixes #13 