### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 dist: xenial
 python:
-  - "3.4"
   - "3.5"
   - "3.5-dev"  # 3.5 development branch
   - "3.6"


### PR DESCRIPTION
cut python3.4 since it takes 5-6x what other versions take to test, and it's outside our supported scope